### PR TITLE
Upgrade to v2.10.3.4602

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shall NOT be edited by hand.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Shipped version:** 2.9.6.4552~ynh1
+**Shipped version:** 2.10.3.4602~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ No se debe editar a mano.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Versión actual:** 2.9.6.4552~ynh1
+**Versión actual:** 2.10.3.4602~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ EZ editatu eskuz.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Paketatutako bertsioa:** 2.9.6.4552~ynh1
+**Paketatutako bertsioa:** 2.10.3.4602~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Version incluse :** 2.9.6.4552~ynh1
+**Version incluse :** 2.10.3.4602~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ NON debe editarse manualmente.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Versión proporcionada:** 2.9.6.4552~ynh1
+**Versión proporcionada:** 2.10.3.4602~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ Ini TIDAK boleh diedit dengan tangan.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Versi terkirim:** 2.9.6.4552~ynh1
+**Versi terkirim:** 2.10.3.4602~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ Hij mag NIET handmatig aangepast worden.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Geleverde versie:** 2.9.6.4552~ynh1
+**Geleverde versie:** 2.10.3.4602~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -20,7 +20,7 @@ Nie powinno być ono edytowane ręcznie.
 
 Music collection manager for Usenet and BitTorrent users
 
-**Dostarczona wersja:** 2.9.6.4552~ynh1
+**Dostarczona wersja:** 2.10.3.4602~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@
 
 Music collection manager for Usenet and BitTorrent users
 
-**Поставляемая версия:** 2.9.6.4552~ynh1
+**Поставляемая версия:** 2.10.3.4602~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@
 
 Music collection manager for Usenet and BitTorrent users
 
-**分发版本：** 2.9.6.4552~ynh1
+**分发版本：** 2.10.3.4602~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Lidarr"
 description.en = "Music collection manager for Usenet and BitTorrent users"
 description.fr = "Gestionnaire de discothèque pour utilisateurs de Usenet et BitTorrent"
 
-version = "2.9.6.4552~ynh1"
+version = "2.10.3.4602~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -41,14 +41,14 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        arm64.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.9.6.4552/Lidarr.master.2.9.6.4552.linux-core-arm64.tar.gz"
-        arm64.sha256 = "2618f0a70828d6f465b964f3a67d20775eee208debc3a38f57ff925bc4cca254"
-        amd64.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.9.6.4552/Lidarr.master.2.9.6.4552.linux-core-x64.tar.gz"
-        amd64.sha256 = "7e039ed3164c7a979cf830e2ffa2aad63e4456ec38e4882faefb9c7679258f5c"
-        armhf.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.9.6.4552/Lidarr.master.2.9.6.4552.linux-core-arm.tar.gz"
-        armhf.sha256 = "a4d9e721957f12bd8c4c5c5ea95dd4d98910d79be24ca9634f3103cd37d5e100"
-        i386.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.9.6.4552/Lidarr.master.2.9.6.4552.linux-core-x86.tar.gz"
-        i386.sha256 = "2dc8aa31e80fe547c9926d78c4e8c1e83de5d30fab3c1485bb3adb4698d1264d"
+        arm64.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.10.3.4602/Lidarr.master.2.10.3.4602.linux-core-arm64.tar.gz"
+        arm64.sha256 = "baeee255ec72b2cdbd43b999dbcd0a7832d95a9eb0c0287e4c98fd5de65cfe54"
+        amd64.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.10.3.4602/Lidarr.master.2.10.3.4602.linux-core-x64.tar.gz"
+        amd64.sha256 = "3f01c851b5f193d54e29df88ec472b4c46258a47f0d8d51d3ba210762416856b"
+        armhf.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.10.3.4602/Lidarr.master.2.10.3.4602.linux-core-arm.tar.gz"
+        armhf.sha256 = "8c0e6fc4f05580284c139a2812ff5735ce1bbe21b6f33991ef4b90517fa82199"
+        i386.url = "https://github.com/Lidarr/Lidarr/releases/download/v2.10.3.4602/Lidarr.master.2.10.3.4602.linux-core-x86.tar.gz"
+        i386.sha256 = "d01f51629f93c87101c4eced9b683018a1f72d36c883a6fdbd60edd001c49c91"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.amd64 = ".*linux-core-x64.tar.gz"


### PR DESCRIPTION
Upgrade sources
- `main` v2.10.3.4602: https://github.com/Lidarr/Lidarr/releases/tag/v2.10.3.4602

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
